### PR TITLE
fix: CI workflow build order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       
+      - name: Build packages
+        run: pnpm build
+      
       - name: Run type checking
         run: pnpm typecheck
       
@@ -33,9 +36,6 @@ jobs:
       
       - name: Run tests
         run: pnpm test
-      
-      - name: Build packages
-        run: pnpm build
 
   security:
     name: Security Audit


### PR DESCRIPTION
## Summary
- Fixed CI workflow to build packages before type checking
- Resolves module resolution errors in CI

## Changes
- Added build step before typecheck in CI workflow
- Removed duplicate build step

This ensures internal packages are built before TypeScript validation runs.