### PR TITLE
fix: allow changeset files and add initial release changeset

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -1,0 +1,12 @@
+---
+"@cove/react-sdk": minor
+---
+
+Initial release of @cove/react-sdk with core functionality:
+
+- Added CoveProvider with initialization lifecycle and state management
+- Enhanced useCove hook to return complete SDK state (isInitialized, isLoading, error, config)
+- Added useFeatureFlag hook for feature flag management
+- Added environment configuration support (development, staging, production)
+- Added debug mode for development logging
+- Exported CoveState type for better TypeScript support

--- a/.gitignore
+++ b/.gitignore
@@ -61,10 +61,7 @@ tmp/
 temp/
 .tmp/
 
-# Changesets (temporary files only)
-.changeset/*.md
-!.changeset/README.md
-!.changeset/config.json
+# Changesets
 
 # Vitest
 vitest.config.*.timestamp-*


### PR DESCRIPTION
## Summary
- Fixed .gitignore to allow changeset files to be committed
- Added changeset for initial @cove/react-sdk release

## Problem
The .gitignore was incorrectly excluding changeset markdown files (except README.md), which prevented the Release workflow from creating version PRs. Changesets need to be committed to the repository for the automated release process to work.

## Solution
- Removed the incorrect `.changeset/*.md` exclusion from .gitignore
- Added the missing changeset for the initial react-sdk release (v0.1.0)

## Impact
After merging this PR, the GitHub Actions Release workflow will:
1. Detect the changeset in the develop branch
2. Automatically create a Release PR from develop to main
3. The Release PR will contain version bumps and CHANGELOG updates

## Checklist
- [x] Fixed .gitignore configuration
- [x] Added changeset for @cove/react-sdk v0.1.0
- [x] Verified changeset file is no longer ignored