### PR TITLE
fix: add proper permissions to Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
     name: Create Release PR
     if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -49,6 +52,9 @@ jobs:
     name: Publish to npm
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Fixed GitHub Actions permissions to allow the Release workflow to create pull requests and push branches.

## Problem
The Release workflow was failing with a 403 permission error when trying to create the Release PR:
```
remote: Permission to getcove/cove-js-sdk.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/getcove/cove-js-sdk/': The requested URL returned error: 403
```

## Solution
Added explicit permissions to both workflow jobs:
- `release-pr` job: Added `contents: write` and `pull-requests: write`
- `publish` job: Added `contents: write` and `id-token: write`

These permissions allow the GitHub Actions bot to:
- Push branches (for changeset-release/develop)
- Create pull requests (for the Release PR)
- Publish packages (when merged to main)

## Impact
After merging this PR, the Release workflow will have the necessary permissions to:
1. Create the Release PR branch
2. Push version updates to that branch
3. Create the PR from develop to main
4. Publish packages when the Release PR is merged

## Testing
The workflow will be tested automatically when this PR is merged to develop.