### PR TITLE
fix: correct release workflow to target main branch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "develop",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
   "privatePackages": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Create Version PR
         uses: changesets/action@v1
         with:
-          # 'version' parameter not needed; creating PR is the default
           commit: "chore: version packages"
           title: "chore: version packages"
         env:
@@ -53,8 +52,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
+      id-token: write  # Only permission needed for npm provenance
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -76,8 +74,6 @@ jobs:
       - name: Build Packages
         run: pnpm build
 
-      - name: Publish to npm
-        run: pnpm changeset publish
-        env:
-          # NPM_TOKEN must be set as a repository secret in GitHub settings
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm with Provenance
+        run: pnpm changeset publish --provenance
+        # No NPM_TOKEN needed - uses OIDC for authentication


### PR DESCRIPTION
## Summary
Fixes the Release workflow to create PRs from develop to main (instead of back to develop) and adds npm provenance for enhanced security.

## Problems Fixed

### 1. Wrong PR Target Branch
- **Issue**: Release PRs were being created from `changeset-release/develop` back to `develop`
- **Root Cause**: `baseBranch` in changeset config was set to `develop`
- **Fix**: Changed `baseBranch` to `main` in `.changeset/config.json`

### 2. Security Enhancement
- **Issue**: Using NPM_TOKEN is less secure than OIDC
- **Fix**: Switched to npm provenance with OIDC authentication
- **Benefits**:
  - No token management needed
  - Cryptographic proof of package origin
  - Enhanced supply chain security

## Changes
- ✅ Set `baseBranch: "main"` in changeset config
- ✅ Added `--provenance` flag to publish command
- ✅ Removed NPM_TOKEN dependency
- ✅ Updated permissions (only `id-token: write` needed for publish)

## Impact
After merging:
1. Release PRs will correctly target `main` branch
2. The flow will be: `feature → develop → main (via Release PR) → npm`
3. Published packages will have npm provenance badges
4. No NPM_TOKEN secret needed (can be removed from GitHub settings)

## Testing
The workflow will be tested when this PR merges to develop and triggers a new Release PR.