### PR TITLE
fix: configure npm OIDC publishing with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
-      id-token: write  # Only permission needed for npm provenance
+      contents: read   # To checkout code
+      id-token: write  # For OIDC token to authenticate with npm
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -67,6 +68,7 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'  # Required for OIDC
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
@@ -75,5 +77,6 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm with Provenance
-        run: pnpm changeset publish --provenance
-        # No NPM_TOKEN needed - uses OIDC for authentication
+        run: pnpm changeset publish --provenance --access public
+        env:
+          NPM_CONFIG_PROVENANCE: true

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -14,7 +14,9 @@
   },
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "peerDependencies": {
     "react": "^18.0.0"


### PR DESCRIPTION
## Summary
Configures the publish workflow to use npm OIDC authentication with provenance, eliminating the need for NPM_TOKEN.

## Problem
The publish workflow was failing with:
```
ENEEDAUTH This command requires you to be logged in to https://registry.npmjs.org/
```

This happened because OIDC wasn't properly configured for npm authentication.

## Solution
### 1. Workflow Configuration
- ✅ Added `registry-url: 'https://registry.npmjs.org'` to setup-node action (REQUIRED for OIDC)
- ✅ Added `contents: read` permission for code checkout
- ✅ Added `--access public` flag to publish command
- ✅ Set `NPM_CONFIG_PROVENANCE: true` environment variable

### 2. Package Configuration  
- ✅ Enhanced publishConfig in package.json with:
  - `registry`: Explicit npm registry URL
  - `provenance`: Enable provenance generation

## Benefits
- 🔒 **No NPM_TOKEN needed** - Pure OIDC authentication
- 🔏 **Cryptographic provenance** - Proves package origin
- 🚀 **Zero-trust security** - No long-lived secrets
- ✅ **Automatic token rotation** - Managed by GitHub

## Testing
After merging this PR and the next Release PR:
1. Packages will be published using OIDC authentication
2. npm packages will show the "Provenance" badge
3. No NPM_TOKEN secret is required in GitHub settings

## Important Note
You may need to configure npm to accept GitHub Actions OIDC tokens. This is typically automatic for public packages with the `--access public` flag.