### PR TITLE
chore: test release workflow targets main branch

### DIFF
--- a/.changeset/fix-release-target.md
+++ b/.changeset/fix-release-target.md
@@ -1,0 +1,5 @@
+---
+"@cove/react-sdk": patch
+---
+
+Fix workflow configuration to ensure Release PRs target main branch


### PR DESCRIPTION
## Summary
Adding a changeset to test that the Release workflow now correctly creates PRs from develop to main (not back to develop).

## Context
Previous Release PRs (#6 and #9) incorrectly targeted develop branch instead of main. This was caused by the changeset config having `baseBranch: "develop"`.

We've since fixed the configuration to use `baseBranch: "main"`, and this PR adds a changeset to test that fix.

## Expected Flow
1. Merge this PR to develop
2. GitHub Actions should create a Release PR from develop → **main** (not develop → develop)
3. The Release PR will bump @cove/react-sdk from 0.1.1 to 0.1.2
4. When the Release PR is merged to main, packages will be published with npm provenance

## Verification
After merging this PR, check that:
- [ ] A new Release PR is created automatically
- [ ] The Release PR base branch is **main** (not develop)
- [ ] The Release PR head branch is `changeset-release/main`