### PR TITLE
feat: rename package scope from @cove to @getcove

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -1,8 +1,8 @@
 ---
-"@cove/react-sdk": minor
+"@getcove/react-sdk": minor
 ---
 
-Initial release of @cove/react-sdk with core functionality:
+Initial release of @getcove/react-sdk with core functionality:
 - CoveProvider for managing SDK initialization and state
 - useCove hook for accessing SDK context
 - useFeatureFlag hook for feature flag management

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A modern TypeScript SDK for building Cove applications.
 
 ## Packages
 
-- `@cove/react-sdk` - React components and hooks for Cove integration
-- `@cove/types` - (Internal) TypeScript type definitions
-- `@cove/utils` - (Internal) Utility functions
+- `@getcove/react-sdk` - React components and hooks for Cove integration
+- `@getcove/types` - (Internal) TypeScript type definitions
+- `@getcove/utils` - (Internal) Utility functions
 
 ## Development
 

--- a/packages/react-sdk/CHANGELOG.md
+++ b/packages/react-sdk/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @cove/react-sdk
+# @getcove/react-sdk
 
 ## 0.0.0
 

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cove/react-sdk",
+  "name": "@getcove/react-sdk",
   "version": "0.0.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -22,8 +22,8 @@
     "react": "^18.0.0"
   },
   "dependencies": {
-    "@cove/types": "workspace:*",
-    "@cove/utils": "workspace:*"
+    "@getcove/types": "workspace:*",
+    "@getcove/utils": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cove/types",
+  "name": "@getcove/types",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cove/utils",
+  "name": "@getcove/utils",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -15,6 +15,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@cove/types": "workspace:*"
+    "@getcove/types": "workspace:*"
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,4 @@
-import type { Nullable, Result } from '@cove/types';
+import type { Nullable, Result } from '@getcove/types';
 
 /**
  * Type guard to check if a value is null or undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,10 +35,10 @@ importers:
 
   packages/react-sdk:
     dependencies:
-      '@cove/types':
+      '@getcove/types':
         specifier: workspace:*
         version: link:../types
-      '@cove/utils':
+      '@getcove/utils':
         specifier: workspace:*
         version: link:../utils
     devDependencies:
@@ -53,7 +53,7 @@ importers:
 
   packages/utils:
     dependencies:
-      '@cove/types':
+      '@getcove/types':
         specifier: workspace:*
         version: link:../types
 


### PR DESCRIPTION
## Summary
- Renamed all package scopes from `@cove` to `@getcove` for npm registry compatibility
- Updated all internal dependencies to use the new scope
- Updated documentation and changelog references

## Changes
- Updated package.json files for all packages
- Updated import statements in source files
- Updated README and CHANGELOG references
- Updated changeset file for initial release

This change is necessary because the `@cove` scope is not available on npm registry.