### PR TITLE
fix: add NPM_TOKEN for organization publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Publish to npm with Provenance
         run: pnpm changeset publish --provenance --access public
         env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
   # Stage 3: Sync main back to develop after successful publish


### PR DESCRIPTION
## Summary
Adds NPM_TOKEN to the publish workflow to enable publishing to the @getcove organization on npm.

## Problem
The workflow was failing with 404 errors when trying to publish @getcove/react-sdk because:
1. OIDC authentication alone isn't sufficient for first-time publishing to an organization
2. npm requires explicit token authentication for organization packages

## Solution
Added NODE_AUTH_TOKEN environment variable that uses the NPM_TOKEN secret.

## Setup Required
Before merging, add NPM_TOKEN secret to the repository:
1. Go to https://www.npmjs.com/settings/getcove/tokens
2. Create a Granular Access Token with read/write permissions for @getcove
3. Add as NPM_TOKEN secret in repository settings