### PR TITLE
fix: add repository field for npm provenance validation

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -13,6 +13,11 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getcove/cove-js-sdk",
+    "directory": "packages/react-sdk"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/",


### PR DESCRIPTION
## Summary
Adds the required repository field to package.json for npm provenance validation.

## Problem
npm publish was failing with E422 error:
```
Error verifying sigstore provenance bundle: Failed to validate repository information: 
package.json: "repository.url" is "", expected to match "https://github.com/getcove/cove-js-sdk"
```

## Solution
Added repository field with the correct GitHub URL to satisfy npm's provenance verification.

This is required when publishing with `--provenance` flag, as npm verifies the package is being published from the declared repository.