### PR TITLE
feat: automated GitHub Release creation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["@changesets/changelog-github", { "repo": "getcove/cove-js-sdk" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/github-releases.md
+++ b/.changeset/github-releases.md
@@ -1,0 +1,5 @@
+---
+"@getcove/react-sdk": patch
+---
+
+Add automated GitHub Release creation after successful npm publication

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,12 @@ jobs:
 
   # Stage 2: Publish when merging to main
   publish:
-    name: Publish to npm
+    name: Publish to npm and Create Release
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     permissions:
       contents: write  # For creating tags and releases
       id-token: write  # For npm Provenance
@@ -54,67 +57,35 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Need full history for tags
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          fetch-depth: 0
+      
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
+      
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
+      
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
+      
       - name: Build Packages
         run: pnpm build
-      - name: Publish to npm with Provenance
+      
+      - name: Create Release Pull Request or Publish
         id: changesets
-        run: pnpm changeset publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      
-      - name: Create Git Tags
-        id: tag
-        if: steps.changesets.outcome == 'success'
-        run: |
-          # Create tags for published packages
-          pnpm changeset tag
-          
-          # Push tags to GitHub
-          git push --follow-tags
-          
-          # Get the latest tag for release creation
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
-          
-          # Check if a tag was created
-          if [ -n "$LATEST_TAG" ]; then
-            echo "published=true" >> $GITHUB_OUTPUT
-            echo "Created tag: $LATEST_TAG"
-          else
-            echo "published=false" >> $GITHUB_OUTPUT
-            echo "No tags were created"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Create GitHub Release
-        if: steps.tag.outputs.published == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: changesets/action@v1
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          name: ${{ steps.tag.outputs.tag }}
-          generate_release_notes: true
-          draft: false
-          prerelease: false
+          publish: pnpm changeset publish --provenance --access public
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Stage 3: Sync main back to develop after successful publish
   sync-develop:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write # For npm Provenance
+      contents: write  # For creating tags and releases
+      id-token: write  # For npm Provenance
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -68,10 +68,40 @@ jobs:
       - name: Build Packages
         run: pnpm build
       - name: Publish to npm with Provenance
+        id: changesets
         run: pnpm changeset publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract Published Packages
+        id: extract
+        if: steps.changesets.outcome == 'success'
+        run: |
+          echo "Extracting published packages info..."
+          # Get the latest tag created by changeset
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          
+          # Check if a tag was created
+          if [ -n "$LATEST_TAG" ]; then
+            echo "published=true" >> $GITHUB_OUTPUT
+          else
+            echo "published=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Create GitHub Release
+        if: steps.extract.outputs.published == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.extract.outputs.tag }}
+          name: ${{ steps.extract.outputs.tag }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Stage 3: Sync main back to develop after successful publish
   sync-develop:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,12 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history for tags
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -72,31 +78,38 @@ jobs:
         run: pnpm changeset publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Extract Published Packages
-        id: extract
+      - name: Create Git Tags
+        id: tag
         if: steps.changesets.outcome == 'success'
         run: |
-          echo "Extracting published packages info..."
-          # Get the latest tag created by changeset
+          # Create tags for published packages
+          pnpm changeset tag
+          
+          # Push tags to GitHub
+          git push --follow-tags
+          
+          # Get the latest tag for release creation
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
           
           # Check if a tag was created
           if [ -n "$LATEST_TAG" ]; then
             echo "published=true" >> $GITHUB_OUTPUT
+            echo "Created tag: $LATEST_TAG"
           else
             echo "published=false" >> $GITHUB_OUTPUT
+            echo "No tags were created"
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Create GitHub Release
-        if: steps.extract.outputs.published == 'true'
+        if: steps.tag.outputs.published == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.extract.outputs.tag }}
-          name: ${{ steps.extract.outputs.tag }}
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
           generate_release_notes: true
           draft: false
           prerelease: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,14 +53,17 @@ flowchart LR
     B --> C[🤖 Auto-creates Release PR]
     C --> D[You: Merge Release PR to main]
     D --> E[🤖 Publishes to npm]
-    E --> F[🤖 Syncs main → develop]
+    E --> F[🤖 Creates Git tags]
+    F --> G[🤖 Creates GitHub Release]
+    G --> H[🤖 Syncs main → develop]
 ```
 
 ### How It Works
 1. **Develop Phase**: Merge features with changesets to `develop`
 2. **Release PR**: Auto-created from `develop` → `main` with version bumps
 3. **Publish**: Merge Release PR triggers npm publish with Provenance
-4. **Sync**: `main` auto-merges back to `develop`
+4. **Tag & Release**: Creates Git tags and GitHub Release with changelog
+5. **Sync**: `main` auto-merges back to `develop`
 
 ## Commands Reference
 
@@ -104,10 +107,18 @@ packages/
 3. Set branch protection for `main` and `develop`
 
 ### npm Setup
-- Uses OIDC authentication (no tokens needed!)
-- Public packages need:
+1. **Create npm organization** (e.g., @getcove)
+2. **Add NPM_TOKEN secret** to GitHub repository:
+   - Create Classic Automation token at npm
+   - Add as `NPM_TOKEN` in repository secrets
+3. **Package configuration**:
 ```json
 {
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getcove/cove-js-sdk",
+    "directory": "packages/your-package"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true
@@ -130,10 +141,14 @@ Bypass if needed: `git commit --no-verify -m "emergency"`
 |--------|-------|---------|
 | `baseBranch` | `"main"` | Release PRs target main |
 | `branch` param | `main` | In changeset action |
+| `changelog` | `@changesets/changelog-github` | GitHub-linked changelogs |
 | Package type | `"module"` | ESM support |
-| npm auth | OIDC | No tokens needed |
+| npm auth | `NPM_TOKEN` | Classic Automation token |
+| GitHub Release | Auto-generated | From Git tags |
 
 ## Help
 
-- Issues: [GitHub Issues](https://github.com/your-org/cove-js-sdk/issues)
+- Issues: [GitHub Issues](https://github.com/getcove/cove-js-sdk/issues)
+- Releases: [GitHub Releases](https://github.com/getcove/cove-js-sdk/releases)
+- Packages: [npm Registry](https://www.npmjs.com/org/getcove)
 - Docs: [README](./README.md)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "ISC",
   "devDependencies": {
     "@biomejs/biome": "^2.1.3",
+    "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.29.5",
     "@types/node": "^24.2.0",
     "@vitest/ui": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.1.3
         version: 2.1.3
+      '@changesets/changelog-github':
+        specifier: ^0.5.1
+        version: 0.5.1
       '@changesets/cli':
         specifier: ^2.29.5
         version: 2.29.5
@@ -125,6 +128,9 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
+  '@changesets/changelog-github@0.5.1':
+    resolution: {integrity: sha512-BVuHtF+hrhUScSoHnJwTELB4/INQxVFc+P/Qdt20BLiBFIHFJDDUaGsZw+8fQeJTRP5hJZrzpt3oZWh0G19rAQ==}
+
   '@changesets/cli@2.29.5':
     resolution: {integrity: sha512-0j0cPq3fgxt2dPdFsg4XvO+6L66RC0pZybT9F4dG5TBrLA3jA/1pNkdTXH9IBBVHkgsKrNKenI3n1mPyPlIydg==}
     hasBin: true
@@ -137,6 +143,9 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+
+  '@changesets/get-github-info@0.6.0':
+    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
 
   '@changesets/get-release-plan@4.0.13':
     resolution: {integrity: sha512-DWG1pus72FcNeXkM12tx+xtExyH/c9I1z+2aXlObH3i9YA7+WZEVaiHzHl03thpvAgWTRaH64MpfHxozfF7Dvg==}
@@ -587,6 +596,9 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
@@ -607,6 +619,10 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
@@ -825,6 +841,15 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -1061,6 +1086,9 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   typescript@5.9.2:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
@@ -1145,6 +1173,12 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1233,6 +1267,14 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
+  '@changesets/changelog-github@0.5.1':
+    dependencies:
+      '@changesets/get-github-info': 0.6.0
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
   '@changesets/cli@2.29.5':
     dependencies:
       '@changesets/apply-release-plan': 7.0.12
@@ -1284,6 +1326,13 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.7.2
+
+  '@changesets/get-github-info@0.6.0':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.13':
     dependencies:
@@ -1654,6 +1703,8 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  dataloader@1.4.0: {}
+
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
@@ -1665,6 +1716,8 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dotenv@8.6.0: {}
 
   emoji-regex@10.4.0: {}
 
@@ -1893,6 +1946,10 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -2097,6 +2154,8 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tr46@0.0.3: {}
+
   typescript@5.9.2: {}
 
   undici-types@7.10.0: {}
@@ -2178,6 +2237,13 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
Implements automated GitHub Release creation after successful npm package publication.

## Key Changes

### Workflow Enhancements
- ✅ Added explicit `changeset tag` step to create Git tags after npm publish
- ✅ Configured Git credentials for tag creation
- ✅ Added GitHub Release creation using softprops/action-gh-release@v2
- ✅ Fixed authentication setup (removed redundant environment variables)
- ✅ Added proper permissions (contents: write) for tag and release creation

### Changelog Improvements
- ✅ Switched to @changesets/changelog-github for better release notes
- ✅ Configured to link PRs and contributors in changelogs

## How It Works

1. **Publish**: Packages are published to npm with provenance
2. **Tag**: `changeset tag` creates Git tags for published versions
3. **Push**: Tags are pushed to GitHub
4. **Release**: GitHub Release is created with auto-generated release notes

## Benefits
- Single source of truth for version history
- Professional GitHub Releases for every npm publication
- Automated changelog generation with PR links
- Complete transparency for users

## Testing
The workflow will be tested when this PR creates a Release PR after merging to develop.