### PR TITLE
fix: correct package name in changeset

### DIFF
--- a/.changeset/loose-islands-call.md
+++ b/.changeset/loose-islands-call.md
@@ -1,5 +1,5 @@
 ---
-"@cove/react-sdk": patch
+"@getcove/react-sdk": patch
 ---
 
 Update documentation to reflect new develop-based release workflow


### PR DESCRIPTION
## Summary
- Fix package name from @cove/react-sdk to @getcove/react-sdk in changeset
- Add changeset for workflow documentation update

## Test plan
- [ ] Verify changeset uses correct package name
- [ ] Confirm changeset will trigger proper version bump