### PR TITLE
Fix CORS error in CoveEmbed iframe sandbox

### DIFF
--- a/.changeset/fix-cors-iframe-sandbox.md
+++ b/.changeset/fix-cors-iframe-sandbox.md
@@ -1,0 +1,5 @@
+---
+"@getcove/react-sdk": patch
+---
+
+Fix CORS error by adding allow-same-origin to iframe sandbox

--- a/packages/react-sdk/src/components/CoveEmbed/CoveEmbed.test.tsx
+++ b/packages/react-sdk/src/components/CoveEmbed/CoveEmbed.test.tsx
@@ -36,7 +36,7 @@ describe('CoveEmbed', () => {
     expect(iframe).toHaveAttribute('width', '100%');
     expect(iframe).toHaveAttribute('id', 'cove-embed');
     expect(iframe).toHaveAttribute('allow', 'camera; microphone; accelerometer');
-    expect(iframe).toHaveAttribute('sandbox', 'allow-scripts allow-forms');
+    expect(iframe).toHaveAttribute('sandbox', 'allow-scripts allow-forms allow-same-origin');
   });
 
   it('uses default props when not provided', () => {

--- a/packages/react-sdk/src/components/CoveEmbed/CoveEmbed.tsx
+++ b/packages/react-sdk/src/components/CoveEmbed/CoveEmbed.tsx
@@ -85,7 +85,7 @@ export const CoveEmbed: React.FC<CoveEmbedProps> = ({
       height={height}
       width={width}
       allow={allow}
-      sandbox="allow-scripts allow-forms"
+      sandbox="allow-scripts allow-forms allow-same-origin"
     />
   );
 };


### PR DESCRIPTION
## Summary
- Fixed CORS error by adding `allow-same-origin` to iframe sandbox attribute
- Updated test to reflect the corrected sandbox attribute value

## Test plan
- [x] All existing tests pass
- [x] Pre-commit hooks pass (linting, typecheck, tests)