### PR TITLE
fix: update env example from session-id to screening-id

### DIFF
--- a/.changeset/update-env-example-screening.md
+++ b/.changeset/update-env-example-screening.md
@@ -1,0 +1,5 @@
+---
+"@getcove/react-sdk": patch
+---
+
+Update environment variable example from session-id to screening-id for better clarity

--- a/apps/react-example/.env.example
+++ b/apps/react-example/.env.example
@@ -1,4 +1,4 @@
 # Cove SDK Environment Variables
 
 # The URL for the Cove embed
-VITE_COVE_EMBED_URL=https://sandbox.cove.dev/s/your-session-id
+VITE_COVE_EMBED_URL=https://sandbox.cove.dev/s/your-screening-id


### PR DESCRIPTION
## Summary
- Updated environment variable example in `apps/react-example/.env.example`
- Changed placeholder from `your-session-id` to `your-screening-id` for better clarity and consistency with current API terminology

## Test plan
- [x] Linting passes
- [x] Type checking passes  
- [x] All tests pass
- [x] Build succeeds