### PR TITLE
fix: add NPM_TOKEN environment variable to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Stage 3: Open a simple sync PR from main to develop


### PR DESCRIPTION
Add NPM_TOKEN to changesets action environment variables alongside existing NODE_AUTH_TOKEN to ensure proper npm authentication during package publishing.